### PR TITLE
Avoid using PHPMailer::set()

### DIFF
--- a/libraries/MY_Email.php
+++ b/libraries/MY_Email.php
@@ -225,7 +225,7 @@ class MY_Email extends CI_Email {
         $this->smtp_crypto = $smtp_crypto;
 
         if ($this->mailer_engine == 'phpmailer') {
-            $this->phpmailer->set('SMTPSecure', $smtp_crypto);
+            $this->phpmailer->SMTPSecure = $smtp_crypto;
         }
 
         return $this;
@@ -238,7 +238,7 @@ class MY_Email extends CI_Email {
         if (!$this->wordwrap) {
 
             if ($this->mailer_engine == 'phpmailer') {
-                $this->phpmailer->set('WordWrap', 0);
+                $this->phpmailer->WordWrap = 0;
             }
         }
 
@@ -263,7 +263,7 @@ class MY_Email extends CI_Email {
         $this->priority = preg_match('/^[1-5]$/', $n) ? (int) $n : 3;
 
         if ($this->mailer_engine == 'phpmailer') {
-            $this->phpmailer->set('Priority', $this->priority);
+            $this->phpmailer->Priority = $this->priority;
         }
 
         return $this;
@@ -301,7 +301,7 @@ class MY_Email extends CI_Email {
                 $return_path = $from;
             }
 
-            $this->phpmailer->set('Sender', $return_path);
+            $this->phpmailer->Sender = $return_path;
 
         } else {
 
@@ -804,9 +804,8 @@ class MY_Email extends CI_Email {
         }
 
         if ($key == 'wrapchars') {
-
             if (!$this->wordwrap) {
-                $this->phpmailer->set('WordWrap', 0);
+                $this->phpmailer->WordWrap = 0;
             }
         }
     }


### PR DESCRIPTION
Don't use the PHPMailer `set()` method; it's inefficient, breaks encapsulation and makes debugging harder - set the appropriate properties directly. There is also a bug in `set()` that has been fixed in HEAD, but I still don't recommend using it. This PR changes all uses of set to set properties directly, except for the generic case when you use a mapping array from CI config properties to PHPMailer equivalents - that's not an unreasonable use of the function.