### PR TITLE
Add DebugOutput setter function

### DIFF
--- a/config/email.php
+++ b/config/email.php
@@ -9,6 +9,7 @@ $config['smtp_pass']        = '';
 $config['smtp_port']        = 25;
 $config['smtp_timeout']     = 30;                       // (in seconds)
 $config['smtp_crypto']      = '';                       // '' or 'tls' or 'ssl'
+$config['debug_output']     = 'html';                   // PHPMailer's SMTP debug output: 'html', 'echo', 'error_log' or user defined function with parameter $str and $level.
 $config['smtp_debug']       = 0;                        // PHPMailer's SMTP debug info level: 0 = off, 1 = commands, 2 = commands and data, 3 = as 2 plus connection status, 4 = low level data output.
 $config['smtp_auto_tls']    = true;                     // Whether to enable TLS encryption automatically if a server supports it, even if `smtp_crypto` is not set to 'tls'.
 $config['smtp_conn_options'] = array();                 // SMTP connection options, an array passed to the function stream_context_create() when connecting via SMTP.

--- a/libraries/MY_Email_2_x.php
+++ b/libraries/MY_Email_2_x.php
@@ -39,6 +39,7 @@ class MY_Email extends CI_Email {
         'send_multipart' => TRUE,
         'bcc_batch_mode' => FALSE,
         'bcc_batch_size' => 200,
+        'debug_output' => 'html',
         'smtp_debug' => 0,
         'encoding' => '8bit',
         'smtp_auto_tls' => true,
@@ -938,6 +939,27 @@ class MY_Email extends CI_Email {
     public function set_bcc_batch_size($value) {
 
         $this->properties['bcc_batch_size'] = (int) $value;
+
+        return $this;
+    }
+
+    // PHPMailer's SMTP debug output.
+    // How to handle debug output.
+    // Options:
+    // `html` Output escaped, line breaks converted to `<br>`, appropriate for browser output. This is default value for CodeIgniter
+    // `echo` Output plain-text as-is, should be avoid in web production
+    // `error_log` Output to error log as configured in php.ini
+    //
+    // Alternatively, you can provide a callable expecting two params: a message string and the debug level:
+    // <code>
+    // function custom_debug($str, $level) {echo "debug level $level; message: $str";};
+    // set_debug_output(custom_debug);
+    // </code>
+    public function set_debug_output($handle) {
+
+        if ($this->mailer_engine == 'phpmailer') {
+            $this->phpmailer->Debugoutput = $handle;
+        }
 
         return $this;
     }

--- a/libraries/MY_Email_3_0_x.php
+++ b/libraries/MY_Email_3_0_x.php
@@ -39,6 +39,7 @@ class MY_Email extends CI_Email {
         'send_multipart' => TRUE,
         'bcc_batch_mode' => FALSE,
         'bcc_batch_size' => 200,
+        'debug_output' => 'html',
         'smtp_debug' => 0,
         'encoding' => '8bit',
         'smtp_auto_tls' => true,
@@ -943,6 +944,27 @@ class MY_Email extends CI_Email {
     public function set_bcc_batch_size($value) {
 
         $this->properties['bcc_batch_size'] = (int) $value;
+
+        return $this;
+    }
+
+    // PHPMailer's SMTP debug output.
+    // How to handle debug output.
+    // Options:
+    // `html` Output escaped, line breaks converted to `<br>`, appropriate for browser output. This is default value for CodeIgniter
+    // `echo` Output plain-text as-is, should be avoid in web production
+    // `error_log` Output to error log as configured in php.ini
+    //
+    // Alternatively, you can provide a callable expecting two params: a message string and the debug level:
+    // <code>
+    // function custom_debug($str, $level) {echo "debug level $level; message: $str";};
+    // set_debug_output(custom_debug);
+    // </code>
+    public function set_debug_output($handle) {
+
+        if ($this->mailer_engine == 'phpmailer') {
+            $this->phpmailer->Debugoutput = $handle;
+        }
 
         return $this;
     }

--- a/libraries/MY_Email_3_1_x.php
+++ b/libraries/MY_Email_3_1_x.php
@@ -39,6 +39,7 @@ class MY_Email extends CI_Email {
         'send_multipart' => TRUE,
         'bcc_batch_mode' => FALSE,
         'bcc_batch_size' => 200,
+        'debug_output' => 'html',
         'smtp_debug' => 0,
         'encoding' => '8bit',
         'smtp_auto_tls' => true,
@@ -935,6 +936,27 @@ class MY_Email extends CI_Email {
     public function set_bcc_batch_size($value) {
 
         $this->properties['bcc_batch_size'] = (int) $value;
+
+        return $this;
+    }
+
+    // PHPMailer's SMTP debug output.
+    // How to handle debug output.
+    // Options:
+    // `html` Output escaped, line breaks converted to `<br>`, appropriate for browser output. This is default value for CodeIgniter
+    // `echo` Output plain-text as-is, should be avoid in web production
+    // `error_log` Output to error log as configured in php.ini
+    //
+    // Alternatively, you can provide a callable expecting two params: a message string and the debug level:
+    // <code>
+    // function custom_debug($str, $level) {echo "debug level $level; message: $str";};
+    // set_debug_output(custom_debug);
+    // </code>
+    public function set_debug_output($handle) {
+
+        if ($this->mailer_engine == 'phpmailer') {
+            $this->phpmailer->Debugoutput = $handle;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Having DebugOutput setter will give developers ability to create their own error handle function which can be very useful.